### PR TITLE
D-TRO JSON Schema v3.2.2 `ChangeableTimePeriodEnd` references fix

### DIFF
--- a/DTRO-v3.2.2.json
+++ b/DTRO-v3.2.2.json
@@ -139,16 +139,16 @@
                 "ChangeableTimePeriod": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/ChangeableTimePeriod"
+                        "$ref": "#/$defs/ChangeableTimePeriod"
                     },
                     "minItems": 1
                 },
                 "SpecialDay": {
-                    "$ref": "#/definitions/SpecialDay"
+                    "$ref": "#/$defs/SpecialDay"
                 },
                 "endType": {
                     "description": "indicates the type of non-precise characteristic time measure used",
-                    "$ref": "#/definitions/ChangeableTimeType",
+                    "$ref": "#/$defs/ChangeableTimeType",
                     "definition": "Time period begins with a fuzzy time or the duration is a fuzzy time"
                 }
             },


### PR DESCRIPTION
## As a contributor 
By submitting this PR I confirm I have read and understood the Github Standards document and understand the role I play in ensuring standards, security, and assurance at DfT.


# Proposed changes

Fixing a wrong path under the `ChangeableTimePeriodEnd` type. Without this fix the JSON Schema is referencing non-existing types, failing on its validation and preventing the generation of the corresponding proxy objects.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (change which fixes the issue https://github.com/department-for-transport-public/D-TRO/issues/8)
- [ ] New feature (change which adds functionality)
- [x] Documentation Update (change to naming or other documentation)

## Points I have checked in my code

- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have checked that my changes have not broken any other functionality
- [x] I have linked to any issues this PR fixes 

## Points for review

- [ ] All of your unit tests pass
- [ ] Your code is clear and easy to understand
- [ ] You have documented any new features
- [x] They can run the code you have written
- [ ] Your changes do not break any other functionality

## Security considerations

- [x] My code does not contain any secrets such as passwords, API keys, etc
- [x] I have not accidentally uploaded any data to Github
- [x] My code does not include any personal information such as names or email addresses

## Who is reviewing this PR?

@JHB9876
